### PR TITLE
fix: complete Spanish translations - add all 31 missing keys

### DIFF
--- a/web/l4h/public/locales/es-ES/common.json
+++ b/web/l4h/public/locales/es-ES/common.json
@@ -1,7 +1,8 @@
 {
   "brand": {
     "title": "Ayuda de Inmigración de EE.UU.",
-    "subtitle": "Impulsado por Law4Hire"
+    "subtitle": "Impulsado por Law4Hire",
+    "tagline": "Tu viaje a los Estados Unidos comienza aquí"
   },
   "loading": "Cargando...",
   "error": "Error",
@@ -20,9 +21,11 @@
   "sort": "Ordenar",
   "refresh": "Actualizar",
   "retry": "Reintentar",
+  "dismiss": "Descartar",
   "confirm": "Confirmar",
   "yes": "Sí",
   "no": "No",
+  "note": "Nota",
   "required": "Requerido",
   "optional": "Opcional",
   "all": "Todos",

--- a/web/l4h/public/locales/es-ES/errors.json
+++ b/web/l4h/public/locales/es-ES/errors.json
@@ -17,7 +17,14 @@
     "loadFailed": "Error al cargar las traducciones para este idioma.",
     "fallbackActive": "Algunas traducciones no están disponibles. Mostrando inglés como respaldo.",
     "missingKey": "Traducción no encontrada para este texto.",
-    "parsingError": "Error al analizar el archivo de traducción."
+    "parsingError": "Error al analizar el archivo de traducción.",
+    "retrying": "Reintentando... ({{count}})",
+    "retryFailed": "Reintento {{count}} falló",
+    "failedLanguages": "Idiomas fallidos: {{languages}}",
+    "networkError": "Error de red al cargar las traducciones.",
+    "serverError": "Error del servidor al cargar las traducciones.",
+    "timeoutError": "La carga de traducciones expiró.",
+    "unknownError": "Ocurrió un error desconocido al cargar las traducciones."
   },
   
   "interview": {

--- a/web/l4h/public/locales/es-ES/interview.json
+++ b/web/l4h/public/locales/es-ES/interview.json
@@ -31,7 +31,13 @@
     "error": "Ocurrió un error al cargar la pregunta",
     "sessionExpired": "Su sesión de entrevista ha expirado. Por favor comience de nuevo.",
     "invalidAnswer": "Por favor proporcione una respuesta válida",
-    "completionFailed": "Error al completar la entrevista. Por favor intente de nuevo."
+    "completionFailed": "Error al completar la entrevista. Por favor intente de nuevo.",
+    "selectVisaDirectly": "Haga clic en un tipo de visa para seleccionarlo directamente:",
+    "selectVisa": "Seleccionar visa tipo {{code}}",
+    "retrySuccess": "¡Reconectado exitosamente! Continuando su entrevista.",
+    "interviewRestarted": "La entrevista ha sido reiniciada. ¡Empezando de nuevo!",
+    "connectionLost": "Conexión perdida. Su progreso ha sido guardado.",
+    "recoveringSession": "Recuperando su sesión de entrevista..."
   },
   
   "completion": {
@@ -85,6 +91,28 @@
     "moreThan3Years": "Más de 3 años",
     "permanent": "Residencia permanente"
   },
+
+  "modal": {
+    "confirmSelection": "Confirmar Selección de Tipo de Visa",
+    "selectionDescription": "Está seleccionando {{visaCode}} como su sugerencia de tipo de visa.",
+    "completionNote": "Esto completará la entrevista y establecerá este tipo de visa como su punto de partida sugerido para trabajar con nuestros profesionales legales.",
+    "legalDisclaimer": "Esto es solo una sugerencia y no es una recomendación legal. Nuestros profesionales legales revisarán su caso y proporcionarán orientación oficial."
+  },
+
+  "errorRecovery": {
+    "title": "Error de Entrevista",
+    "description": "Encontramos un problema con su sesión de entrevista.",
+    "options": {
+      "retry": "Intentar de Nuevo",
+      "restart": "Reiniciar Entrevista",
+      "dashboard": "Volver al Panel de Control"
+    },
+    "retryDescription": "Intentar continuar desde donde lo dejó.",
+    "restartDescription": "Comenzar la entrevista de nuevo desde el principio.",
+    "dashboardDescription": "Regresar a su panel de control e intentar más tarde.",
+    "retryAttempt": "Intento de reintento {{count}} de 3",
+    "maxRetriesReached": "Se alcanzó el máximo de intentos de reintento. Por favor reinicie o regrese al panel de control."
+  },
   
   "errors": {
     "loadingFailed": "Error al cargar las preguntas de la entrevista",
@@ -92,6 +120,7 @@
     "sessionInvalid": "Su sesión de entrevista es inválida",
     "networkError": "Error de red. Por favor verifique su conexión.",
     "serverError": "Error del servidor. Por favor intente más tarde.",
-    "unexpectedError": "Ocurrió un error inesperado"
+    "unexpectedError": "Ocurrió un error inesperado",
+    "restartFailed": "Error al reiniciar la entrevista. Por favor intente de nuevo."
   }
 }


### PR DESCRIPTION
Fixed all missing Spanish translation keys across three files:
- common.json: Added 3 missing keys (brand.tagline, dismiss, note)
- errors.json: Added 7 missing translation error keys
- interview.json: Added 21 missing keys including modal and errorRecovery sections

Before: 31 missing translations (94.36% complete)
After: 0 missing translations (100% complete)

All Spanish translations are now complete with 1493 total keys translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR completes the Spanish (es-ES) translation coverage by adding 31 missing translation keys across three locale files. It adds 3 keys to `common.json` (brand tagline, dismiss, note), 7 error-related keys to `errors.json` (retry messages, network/server/timeout errors), and 21 keys to `interview.json` (modal confirmation dialogs and error recovery UI sections). This brings the Spanish translation completion from 94.36% to 100% with all 1493 keys now translated.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `web/l4h/public/locales/es-ES/common.json` |
| 2 | `web/l4h/public/locales/es-ES/errors.json` |
| 3 | `web/l4h/public/locales/es-ES/interview.json` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->